### PR TITLE
fix: improve display of keys of Map objects

### DIFF
--- a/src/Component/react-inspector/index.tsx
+++ b/src/Component/react-inspector/index.tsx
@@ -5,7 +5,8 @@ import {
   Inspector,
   ObjectLabel,
   ObjectName,
-  ObjectRootLabel
+  ObjectRootLabel,
+  ObjectValue
 } from 'react-inspector'
 import ObjectPreview from 'react-inspector/lib/object-inspector/ObjectPreview'
 
@@ -16,6 +17,18 @@ interface Props {
   theme?: Context
   data: any
 }
+
+const CustomObjectLabel = ({ name, data, isNonenumerable = false }) => (
+  <span>
+    {typeof name === 'string' ? (
+      <ObjectName name={name} dimmed={isNonenumerable} />
+    ) : (
+      <ObjectPreview data={name} />
+    )}
+    <span>: </span>
+    <ObjectValue object={data} />
+  </span>
+)
 
 class CustomInspector extends React.PureComponent<Props, any> {
   render() {
@@ -79,26 +92,6 @@ class CustomInspector extends React.PureComponent<Props, any> {
     return null
   }
 
-  getCustomName(name: any) {
-    if (typeof name === 'object') {
-      let customName: string
-
-      try {
-        customName = JSON.stringify(name)
-      } catch (e) {
-        customName = String(name)
-      }
-
-      return customName
-    }
-
-    if (typeof name === 'function') {
-      return '' + name
-    }
-
-    return name
-  }
-
   nodeRenderer(props: any) {
     let { depth, name, data, isNonenumerable } = props
 
@@ -119,18 +112,17 @@ class CustomInspector extends React.PureComponent<Props, any> {
         </Constructor>
       )
 
-    const customName = this.getCustomName(name)
     const customNode = this.getCustomNode(data)
 
     return customNode ? (
       <Root>
-        <ObjectName name={customName} />
+        <ObjectName name={name} />
         <span>: </span>
         {customNode}
       </Root>
     ) : (
-      <ObjectLabel
-        name={customName}
+      <CustomObjectLabel
+        name={name}
         data={data}
         isNonenumerable={isNonenumerable}
       />

--- a/src/Component/react-inspector/index.tsx
+++ b/src/Component/react-inspector/index.tsx
@@ -79,6 +79,26 @@ class CustomInspector extends React.PureComponent<Props, any> {
     return null
   }
 
+  getCustomName(name: any) {
+    if (typeof name === 'object') {
+      let customName: string
+
+      try {
+        customName = JSON.stringify(name)
+      } catch (e) {
+        customName = String(name)
+      }
+
+      return customName
+    }
+
+    if (typeof name === 'function') {
+      return '' + name
+    }
+
+    return name
+  }
+
   nodeRenderer(props: any) {
     let { depth, name, data, isNonenumerable } = props
 
@@ -99,15 +119,21 @@ class CustomInspector extends React.PureComponent<Props, any> {
         </Constructor>
       )
 
+    const customName = this.getCustomName(name)
     const customNode = this.getCustomNode(data)
+
     return customNode ? (
       <Root>
-        <ObjectName name={name} />
+        <ObjectName name={customName} />
         <span>: </span>
         {customNode}
       </Root>
     ) : (
-      <ObjectLabel name={name} data={data} isNonenumerable={isNonenumerable} />
+      <ObjectLabel
+        name={customName}
+        data={data}
+        isNonenumerable={isNonenumerable}
+      />
     )
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix. Closes #34.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
When a `Map` has keys of type `object` and `function`, the library doesn't work properly.
<!-- You can also link to an open issue here -->

## What is the new behavior?
~We are stringifying the keys with the types mentioned above.~

EDIT: This behavior was fixed in [react-inspector](https://github.com/storybookjs/react-inspector/pull/88). However, they released in v4, which doesn't expose the `ObjectPreview` component. My workaround was to copy-pasted the new `ObjectLabel` component to inside this library.
<!-- if this is a feature change -->

## Notes

I'll open a PR to expose `ObjectPreview` and if it gets merged, we can update `react-inspector` here and remove the workaround.
