### PR TITLE
fix: reinforce string formatter against XSS attacks

### DIFF
--- a/src/Component/devtools-parser/format-message.ts
+++ b/src/Component/devtools-parser/format-message.ts
@@ -20,6 +20,10 @@ export default function formatWithSubstitutionString(
   const formatters: any = {}
 
   function stringFormatter(obj: any) {
+    if (typeof obj !== 'string') {
+      return ''
+    }
+
     return String(obj)
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.
<!-- Is it a Bug fix, feature, docs update, ... -->

## What is the current behavior?
We are using a custom version of this package on CodeSandbox because it's possible to exploit the `stringFormatter` function in order to render a DOM node - see [this sandbox](https://codesandbox.io/s/codesandbox-exploit-bhi12), even though is not possible to exploit it anymore.
<!-- You can also link to an open issue here -->

## What is the new behavior?
We are preventing exploits by checking for the type of the param on `stringFormatter`, just like in [our custom version](https://github.com/CompuIves/console-feed/blob/build2/lib/Component/devtools-parser/format-message.js#L17).
<!-- if this is a feature change -->
