### PR TITLE
fix: update react-inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@emotion/styled": "^10.0.12",
     "emotion-theming": "^10.0.10",
     "linkifyjs": "^2.1.6",
-    "react-inspector": "^2.2.2"
+    "react-inspector": "^3.0.2"
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.9",

--- a/src/Component/react-inspector/index.tsx
+++ b/src/Component/react-inspector/index.tsx
@@ -8,7 +8,7 @@ import {
   ObjectRootLabel,
   ObjectValue
 } from 'react-inspector'
-import ObjectPreview from 'react-inspector/lib/object-inspector/ObjectPreview'
+import { ObjectPreview } from 'react-inspector/dist/cjs/react-inspector'
 
 import { Context } from '../../definitions/Component'
 import { Constructor, HTML, Root, Table } from './elements'

--- a/src/Component/react-inspector/index.tsx
+++ b/src/Component/react-inspector/index.tsx
@@ -6,9 +6,9 @@ import {
   ObjectLabel,
   ObjectName,
   ObjectRootLabel,
-  ObjectValue
+  ObjectValue,
+  ObjectPreview
 } from 'react-inspector'
-import { ObjectPreview } from 'react-inspector/dist/cjs/react-inspector'
 
 import { Context } from '../../definitions/Component'
 import { Constructor, HTML, Root, Table } from './elements'


### PR DESCRIPTION
* Version update react-inspector (2.2.2 => 3.0.2)
* `react-inspector` version 2 is the old version ( https://www.npmjs.com/package/react-inspector#install )
* Due to the use of react-inspector 2 version, it cannot be used in react 16+ strict mode.
* Fix import code due to react-inspector update