### PR TITLE
Make sure `Root` element uses all available space

### DIFF
--- a/src/Component/elements.tsx
+++ b/src/Component/elements.tsx
@@ -17,7 +17,8 @@ const Themed = (
  * console-feed
  */
 export const Root = styled('div')({
-  wordBreak: 'break-word'
+  wordBreak: 'break-word',
+  width: '100%',
 })
 
 /**


### PR DESCRIPTION
We are trying to adopt console-feed in https://github.com/facebook/flipper, however I noticed that the feed (Root element) doesn't consume all available space as long as there are no long messages logged (see the first warning in the screenshot). This PR fixes that

![Screenshot from 2020-08-19 13-36-26](https://user-images.githubusercontent.com/1820292/90635627-540a9800-e221-11ea-9841-ca179400b159.png)
 