### PR TITLE
fix: empty logs grouping

### DIFF
--- a/src/Component/index.tsx
+++ b/src/Component/index.tsx
@@ -32,7 +32,13 @@ class Console extends React.PureComponent<Props, any> {
   })
 
   render() {
-    let { filter = [], logs = [], searchKeywords, logFilter } = this.props
+    let {
+      filter = [],
+      logs = [],
+      searchKeywords,
+      logFilter,
+      logGrouping,
+    } = this.props
 
     if (searchKeywords) {
       const regex = new RegExp(searchKeywords)
@@ -51,25 +57,28 @@ class Console extends React.PureComponent<Props, any> {
       logs = logs.filter(filterFun)
     }
 
-    // @ts-ignore
-    logs = logs.reduce((acc, log) => {
-      const prevLog = acc[acc.length - 1]
+    if (logGrouping) {
+      // @ts-ignore
+      logs = logs.reduce((acc, log) => {
+        const prevLog = acc[acc.length - 1]
 
-      if (
-        prevLog &&
-        prevLog.amount &&
-        prevLog.method === log.method &&
-        prevLog.data.every((value, i) => log.data[i] === value)
-      ) {
-        prevLog.amount += 1
+        if (
+          prevLog &&
+          prevLog.amount &&
+          prevLog.method === log.method &&
+          prevLog.data.length === log.data.length &&
+          prevLog.data.every((value, i) => log.data[i] === value)
+        ) {
+          prevLog.amount += 1
+
+          return acc
+        }
+
+        acc.push({ ...log, amount: 1 })
 
         return acc
-      }
-
-      acc.push({ ...log, amount: 1 })
-
-      return acc
-    }, [])
+      }, [])
+    }
 
     return (
       <ThemeProvider theme={this.theme}>

--- a/src/Component/index.tsx
+++ b/src/Component/index.tsx
@@ -37,7 +37,7 @@ class Console extends React.PureComponent<Props, any> {
       logs = [],
       searchKeywords,
       logFilter,
-      logGrouping,
+      logGrouping = true,
     } = this.props
 
     if (searchKeywords) {

--- a/src/definitions/Component.d.ts
+++ b/src/definitions/Component.d.ts
@@ -25,6 +25,7 @@ export interface Props {
   filter?: Methods[]
   searchKeywords?: string
   logFilter?: Function
+  logGrouping?: Boolean
 }
 
 export interface MessageProps {


### PR DESCRIPTION
Fixed issue (https://github.com/samdenty/console-feed/issues/59) with empy logs grouping and adding a `logGrouping` option to enable logs grouping