### PR TITLE
Use log.id as list item key if available

### DIFF
--- a/src/Component/index.tsx
+++ b/src/Component/index.tsx
@@ -91,7 +91,7 @@ class Console extends React.PureComponent<Props, any> {
               filter.indexOf(log.method) === -1
 
             return filtered ? null : (
-              <Message log={log} key={`${log.method}-${i}`} />
+              <Message log={log} key={log.id || `${log.method}-${i}`} />
             )
           })}
         </Root>


### PR DESCRIPTION
This fixes #69 by using a unique ID as the [list item key](https://reactjs.org/docs/lists-and-keys.html#keys). Logs captured by the `console.log` hook already have a GUID.