### PR TITLE
add support for optional log timestamp

### DIFF
--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from 'react-dom'
 import update from 'immutability-helper'
 import { Hook, Console, Decode } from '../../src'
+import { Message } from '../../src/definitions/Component'
 
 const iframe = document.createElement('iframe')
 iframe.src = './iframe.html'
@@ -13,19 +14,39 @@ class App extends React.Component {
       {
         method: 'result',
         data: ['Result'],
+        timestamp: this.getTimestamp()
       },
       {
         method: 'command',
         data: ['Command'],
+        timestamp: this.getTimestamp()
       },
     ] as any[],
     filter: [],
     searchKeywords: '',
   }
 
+  getNumberStringWithWidth(num: Number, width: number)
+  {
+    const str = num.toString();
+    if( width > str.length) return "0".repeat(width - str.length) + str;
+    return str.substr(0, width);
+  }
+
+  getTimestamp()
+  {
+    const date = new Date();
+    const h = this.getNumberStringWithWidth(date.getHours(), 2);
+    const min = this.getNumberStringWithWidth(date.getMinutes(), 2);
+    const sec = this.getNumberStringWithWidth(date.getSeconds(), 2);
+    const ms = this.getNumberStringWithWidth(date.getMilliseconds(), 3);
+    return `${h}:${min}:${sec}.${ms}`
+  }
+
   componentDidMount() {
     Hook((iframe.contentWindow as any).console, (log) => {
       const decoded = Decode(log)
+      decoded.timestamp = this.getTimestamp()
       this.setState((state) => update(state, { logs: { $push: [decoded] } }))
     })
   }

--- a/src/Component/Message.tsx
+++ b/src/Component/Message.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { MessageProps, Theme } from '../definitions/Component'
 import { ThemeProvider } from 'emotion-theming'
 
-import { Message, Icon, Content, AmountIcon } from './elements'
+import { Message, Icon, Content, AmountIcon, Timestamp } from './elements'
 
 import Formatted from './message-parsers/Formatted'
 import ObjectTree from './message-parsers/Object'
@@ -27,6 +27,7 @@ class ConsoleMessage extends React.Component<MessageProps, any> {
       <ThemeProvider theme={this.theme}>
         <Message data-method={log.method}>
           {log.amount > 1 ? <AmountIcon>{log.amount}</AmountIcon> : <Icon />}
+          {log.timestamp ? <Timestamp>{log.timestamp}</Timestamp> : <span/>}
           <Content>{this.getNode()}</Content>
         </Message>
       </ThemeProvider>

--- a/src/Component/elements.tsx
+++ b/src/Component/elements.tsx
@@ -77,6 +77,16 @@ export const AmountIcon = styled('div')(({ theme: { styles, method } }) => ({
 }))
 
 /**
+ * timestamp
+ */
+ export const Timestamp = styled('div')(({ theme: { styles, method } }) => ({
+  padding: '3px 0px 0px 5px',
+  width: '110px',
+  height: styles.LOG_ICON_HEIGHT,
+  color: 'dimgray',
+}))
+
+/**
  * console-content
  */
 export const Content = styled('div')(({ theme: { styles } }) => ({

--- a/src/definitions/Console.d.ts
+++ b/src/definitions/Console.d.ts
@@ -17,6 +17,7 @@ export type Methods = _Methods
 export interface Message {
   method: Methods
   data?: any[]
+  timestamp?: string
 }
 
 export type Callback = (encoded: Message, message: Payload) => void


### PR DESCRIPTION
Adds support for an optional timestamp field on each log entry. 

![image](https://user-images.githubusercontent.com/17261553/130837671-0206b04a-4b20-4aaf-a62f-c9629925e729.png)
