### PR TITLE
fix(performance): Add transformer lookup shortcut for common types

### DIFF
--- a/src/Transform/Function.ts
+++ b/src/Transform/Function.ts
@@ -9,6 +9,7 @@ interface Storage {
  */
 export default {
   type: 'Function',
+  lookup: Function,
   shouldTransform(type: any, obj: any) {
     return typeof obj === 'function'
   },
@@ -23,31 +24,31 @@ export default {
     return {
       name: func.name,
       body,
-      proto: Object.getPrototypeOf(func).constructor.name
+      proto: Object.getPrototypeOf(func).constructor.name,
     }
   },
   fromSerializable(data: Storage) {
     try {
-      const tempFunc = function() {}
+      const tempFunc = function () {}
 
       if (typeof data.name === 'string') {
         Object.defineProperty(tempFunc, 'name', {
           value: data.name,
-          writable: false
+          writable: false,
         })
       }
 
       if (typeof data.body === 'string') {
         Object.defineProperty(tempFunc, 'body', {
           value: data.body,
-          writable: false
+          writable: false,
         })
       }
 
       if (typeof data.proto === 'string') {
         // @ts-ignore
         tempFunc.constructor = {
-          name: data.proto
+          name: data.proto,
         }
       }
 
@@ -55,5 +56,5 @@ export default {
     } catch (e) {
       return data
     }
-  }
+  },
 }

--- a/src/Transform/arithmetic.ts
+++ b/src/Transform/arithmetic.ts
@@ -1,7 +1,7 @@
 enum Arithmetic {
   infinity,
   minusInfinity,
-  minusZero
+  minusZero,
 }
 
 function isMinusZero(value) {
@@ -10,6 +10,7 @@ function isMinusZero(value) {
 
 export default {
   type: 'Arithmetic',
+  lookup: Number,
   shouldTransform(type: any, value: any) {
     return (
       type === 'number' &&
@@ -20,8 +21,8 @@ export default {
     return value === Infinity
       ? Arithmetic.infinity
       : value === -Infinity
-        ? Arithmetic.minusInfinity
-        : Arithmetic.minusZero
+      ? Arithmetic.minusInfinity
+      : Arithmetic.minusZero
   },
   fromSerializable(data: Arithmetic) {
     if (data === Arithmetic.infinity) return Infinity
@@ -29,5 +30,5 @@ export default {
     if (data === Arithmetic.minusZero) return -0
 
     return data
-  }
+  },
 }


### PR DESCRIPTION
A good chunk of time is spend trying to find the right transformer for an object. I added an easy lookup for objects that we have a transformer for. 