### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ const LogsContainer = () => {
 
   // run once!
   useEffect(() => {
-    Hook(
+    const hookedConsole = Hook(
       window.console,
       (log) => setLogs((currLogs) => [...currLogs, log]),
       false
     )
-    return () => Unhook(window.console)
+    return () => Unhook(hookedConsole)
   }, [])
 
   return <Console logs={logs} variant="dark" />


### PR DESCRIPTION
The example for hooks did not use the `HookedConsole` in the cleanup function.
It would probably still work since it's the same object but it creates a typescript error.

I just noticed this and thought it might be wise to provide a typesafe example.