### PR TITLE
chore(pkg): support react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "peerDependencies": {
-    "react": "^15.x || ^16.x || ^17.x"
+    "react": "^15.x || ^16.x || ^17.x || ^18.x"
   },
   "files": [
     "es",


### PR DESCRIPTION
I'm using **React 18.x.x** and I'm getting a dependency conflict when I try to install the `console-feed` module.
In fact, it seems to work fine with React 18 without any issues. (refer to #114 comment)

I fixed the module installation error by adding the React 18 dependency to `package.json`.

fixes #114 


```shell
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: console-feed@3.4.3
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   react@"^18.2.0" from the root project
npm ERR!   peer react@">=16.3.0" from @emotion/core@10.3.1
npm ERR!   node_modules/@emotion/core
npm ERR!     peer @emotion/core@"^10.0.28" from @emotion/styled-base@10.3.0
npm ERR!     node_modules/@emotion/styled-base
npm ERR!       @emotion/styled-base@"^10.3.0" from @emotion/styled@10.3.0
npm ERR!       node_modules/console-feed/node_modules/@emotion/styled
npm ERR!         @emotion/styled@"^10.0.12" from console-feed@3.4.3
npm ERR!         node_modules/console-feed
npm ERR!     @emotion/core@"^10.0.10" from console-feed@3.4.3
npm ERR!     node_modules/console-feed
npm ERR!       console-feed@"^3.4.3" from the root project
npm ERR!     2 more (@emotion/styled, emotion-theming)
npm ERR!   24 more (@emotion/react, @emotion/styled, @emotion/styled-base, ...)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^15.x || ^16.x || ^17.x" from console-feed@3.4.3
npm ERR! node_modules/console-feed
npm ERR!   console-feed@"^3.4.3" from the root project
```