### PR TITLE
fix: array[(array.length - 1)].split is not a function (fix #108)

### DIFF
--- a/src/Component/__tests__/Console.spec.tsx
+++ b/src/Component/__tests__/Console.spec.tsx
@@ -43,6 +43,27 @@ it('formats messages', () => {
   expect(html).toContain('[<span style="color:rgb(28, 0, 207)">2</span>]')
 })
 
+it('various data types', () => {
+  const result = shallow(
+    <Console
+      logs={[
+        {
+          method: 'log',
+          id: 'id',
+          data: [1, 'test', { foo: 'bar' }, [1, 2, 3, 4, 5]],
+        },
+      ]}
+    />
+  )
+
+  const html = result.html()
+  expect(html).toContain('<span style="color:rgb(233,63,59)">test</span>')
+  expect(html).toContain('<span style="color:rgb(136, 19, 145)">foo</span>:')
+  expect(html).toContain(
+    '<span style="color:rgb(233,63,59)">&quot;bar&quot;</span>'
+  )
+})
+
 it('skips non-existent substitution', () => {
   const result = shallow(
     <Console

--- a/src/Component/react-inspector/index.tsx
+++ b/src/Component/react-inspector/index.tsx
@@ -164,8 +164,15 @@ class CustomInspector extends React.PureComponent<Props, any> {
     if (Array.isArray(data)) {
       const arrayLength = getArrayLength(data)
       const maxProperties = styles.OBJECT_PREVIEW_ARRAY_MAX_PROPERTIES
+
+      if (
+        typeof data[data.length - 1] === 'string' &&
+        data[data.length - 1].includes(REMAINING_KEY)
+      ) {
+        data = data.slice(0, -1)
+      }
+
       const previewArray = data
-        .slice(0, -1)
         .slice(0, maxProperties)
         .map((element, index) => {
           if (Array.isArray(element)) {

--- a/src/Component/react-inspector/index.tsx
+++ b/src/Component/react-inspector/index.tsx
@@ -30,8 +30,19 @@ function intersperse(arr, sep) {
 }
 
 const getArrayLength = (array: Array<any>) => {
-  const remaining = parseInt(array[array.length - 1].split(REMAINING_KEY)[1])
-  return array.length - 1 + remaining
+  const remainingKeyCount = array[array.length - 1]
+    .toString()
+    .split(REMAINING_KEY)
+
+  if (remainingKeyCount[1] === undefined) {
+    return array.length
+  } else {
+    const remaining = parseInt(
+      array[array.length - 1].toString().split(REMAINING_KEY)[1]
+    )
+
+    return array.length - 1 + remaining
+  }
 }
 
 const CustomObjectRootLabel = ({ name, data }) => {


### PR DESCRIPTION
I ran into two problems with the latest version of `console-feed`. fixes #108.

1. `Uncaught TypeError: array[(array.length - 1)].split is not a function` (#108)
2. The last array item was not displayed.

This issue occurred when the data type was an `array`, or when it was an array and short in length.

```javascript
<Console
      logs={[
        {
          method: 'log',
          id: 'id',
          data: [[1, 2, 3, 4, 5]],
        },
      ]}
/>
```

In this case, an error will be thrown, and `5` will not be output normally, even if it works.

This PR fixes the above two issues and adds tests for them.