### PR TITLE
fix: Throw error when `getArrayLength` receives an empty array

### DIFF
--- a/src/Component/__tests__/Console.spec.tsx
+++ b/src/Component/__tests__/Console.spec.tsx
@@ -50,7 +50,16 @@ it('various data types', () => {
         {
           method: 'log',
           id: 'id',
-          data: [1, 'test', { foo: 'bar' }, [1, 2, 3, 4, 5]],
+          data: [
+            1,
+            'test',
+            { foo: 'bar' },
+            [1, 2, 3, 4, 5],
+            [],
+            [{}],
+            {},
+            null,
+          ],
         },
       ]}
     />

--- a/src/Component/react-inspector/index.tsx
+++ b/src/Component/react-inspector/index.tsx
@@ -30,6 +30,10 @@ function intersperse(arr, sep) {
 }
 
 const getArrayLength = (array: Array<any>) => {
+  if (!array || array.length < 1) {
+    return 0
+  }
+
   const remainingKeyCount = array[array.length - 1]
     .toString()
     .split(REMAINING_KEY)


### PR DESCRIPTION
I didn't think of a handling case for empty arrays in my previous PR (#118), I'm a super idiot!

I apologize for the hassle with this ongoing fix. This situation happens frequently and i hope this fix gets reviewed quickly.

---

This PR resolved the issue in the reproduction below:

### How to Reproduce:

For example, suppose you have the following situation:

```javascript
<Console
    logs={[
      {
        method: 'log',
        id: 'id',
        data: [[], {}, [{}]],
      },
    ]}
/>
```

If so, you should see the following error in the console below:

```shell
TypeError: Cannot read properties of undefined (reading 'toString')

      38 |     return array.length
      39 |   } else {
    > 40 |     const remaining = parseInt(
      41 |       array[array.length - 1].toString().split(REMAINING_KEY)[1]
      42 |     )
      43 | 
      
      at getArrayLength (src/Component/react-inspector/index.tsx:40:5)
      at CustomInspector.getCustomNode (src/Component/react-inspector/index.tsx:165:27)
      at CustomInspector.nodeRenderer (src/Component/react-inspector/index.tsx:213:31)
      at processChild (node_modules/react-dom/cjs/react-dom-server.node.development.js:3043:14)

```

Regards,