### PR TITLE
chore(pkg): add `.idea` directory in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /lib
 /node_modules
 /umd
+/.idea
 npm-debug.log*
 .DS_Store
 yarn-error.log


### PR DESCRIPTION
There are no functional changes due to this PR.

Make the `.idea` directory that is automatically created when using the **IntelliJ**-based **IDE** be ignored on commit.

This is a directory that contains personalized settings and does not need to be included in the project.

Additionally, there may be a `.vscode` directory (VSCode), but this is not included here as it uses a different policy per project.

Regards,