### PR TITLE
feat: add `bigint` support

### DIFF
--- a/demo/public/iframe.html
+++ b/demo/public/iframe.html
@@ -86,6 +86,10 @@
       console.log(longMap)
       console.timeEnd('Render time')
       console.dir(new Error('hmm'))
+
+      console.log('Positive BigInt', 1n)
+      console.log('Zero BigInt', 0n)
+      console.log('Negative BigInt', -1n)
     }, 1500)
   </script>
 </body>

--- a/src/Hook/__tests__/Hook.spec.tsx
+++ b/src/Hook/__tests__/Hook.spec.tsx
@@ -21,6 +21,15 @@ it('decodes messages', () => {
   expect(decoded.data).toMatchSnapshot()
 })
 
+it('correctly encodes a `bigint`', async () => {
+  const result = await Log('warn', BigInt(1))
+  expect(result).toBeTruthy()
+
+  const decoded = Decode(result)
+  expect(decoded.method).toEqual('warn')
+  expect(decoded.data).toMatchSnapshot()
+})
+
 it('correctly encodes a HTMLElement', async () => {
   const result = await Log('warn', document.documentElement)
   expect(result).toBeTruthy()

--- a/src/Hook/__tests__/__snapshots__/Hook.spec.tsx.snap
+++ b/src/Hook/__tests__/__snapshots__/Hook.spec.tsx.snap
@@ -6,6 +6,12 @@ Array [
 ]
 `;
 
+exports[`correctly encodes a \`bigint\` 1`] = `
+Array [
+  BigInt {},
+]
+`;
+
 exports[`correctly encodes a HTMLElement 1`] = `
 Array [
   <html>

--- a/src/Transform/BigInt.ts
+++ b/src/Transform/BigInt.ts
@@ -1,0 +1,15 @@
+/**
+ * Serialize a `bigint` to a string
+ */
+export default {
+  type: 'BigInt',
+  shouldTransform(_type: any, obj: any) {
+    return typeof obj === 'bigint'
+  },
+  toSerializable(value: bigint) {
+    return `${value}n`
+  },
+  fromSerializable(data: string) {
+    return BigInt(data.slice(0, -1))
+  },
+}

--- a/src/Transform/index.ts
+++ b/src/Transform/index.ts
@@ -1,12 +1,13 @@
 import { Message } from '../definitions/Console'
 import Arithmetic from './arithmetic'
+import BigInt from './BigInt'
 import Function from './Function'
 import HTML from './HTML'
 import Map from './Map'
 
 import Replicator from './replicator'
 
-const transforms = [HTML, Function, Arithmetic, Map]
+const transforms = [HTML, Function, Arithmetic, Map, BigInt]
 
 const replicator = new Replicator()
 replicator.addTransforms(transforms)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "module": "commonjs",
     "target": "es3",
-    "lib": ["es6", "dom"],
+    "lib": ["es6", "dom", "ES2020.BigInt"],
     "inlineSourceMap": true,
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,


### PR DESCRIPTION
1. I discovered that the codesandbox.io console dies when you try to log a `bigint`
2. I found https://github.com/codesandbox/codesandbox-client/issues/5981
3. That led me to https://github.com/samdenty/console-feed/issues/90

This PR introduces `bigint` serialization support so that you can do this:

```
console.log(1n, 0n, -1n)
```

Fixes https://github.com/codesandbox/codesandbox-client/issues/5981
Fixes https://github.com/samdenty/console-feed/issues/90