### PR TITLE
Allow overriding the Message component

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ A string value to filter logs
 
 If you want to use a custom log filter function, you can provide your own implementation
 
+### `components?: ComponentOverrides`
+
+To fully customize layout and rendering of the console feed, you can provide your own React
+components. Currently, only the `Message` component is customizable.
+
 ## Log methods
 
 Each log has a method assigned to it. The method is used to determine the style of the message and for the `filter` prop.

--- a/src/Component/Message.tsx
+++ b/src/Component/Message.tsx
@@ -30,10 +30,13 @@ class ConsoleMessage extends React.Component<MessageProps, any> {
   })
 
   render() {
-    const { log } = this.props
+    const { log, components } = this.props
+    const node = this.getNode()
+    const MessageComponent = components?.Message || Message
+
     return (
       <ThemeProvider theme={this.theme}>
-        <Message data-method={log.method}>
+        <MessageComponent log={log} node={node} data-method={log.method}>
           <IconContainer>
             {/* Align icon to adjacent text, and let the icon can be different size than the text */}
             <InlineCenter>
@@ -45,8 +48,8 @@ class ConsoleMessage extends React.Component<MessageProps, any> {
             </InlineCenter>
           </IconContainer>
           {log.timestamp ? <Timestamp>{log.timestamp}</Timestamp> : <span />}
-          <Content>{this.getNode()}</Content>
-        </Message>
+          <Content>{node}</Content>
+        </MessageComponent>
       </ThemeProvider>
     )
   }

--- a/src/Component/index.tsx
+++ b/src/Component/index.tsx
@@ -115,6 +115,7 @@ class Console extends React.PureComponent<Props, any> {
                 log={log}
                 key={log.id || `${log.method}-${i}`}
                 linkifyOptions={this.props.linkifyOptions}
+                components={this.props.components}
               />
             )
           })}

--- a/src/definitions/Component.d.ts
+++ b/src/definitions/Component.d.ts
@@ -2,6 +2,7 @@ import { Payload } from './Payload'
 import { Styles } from './Styles'
 import { Methods } from './Methods'
 import type { Options } from 'linkifyjs'
+import { ComponentOverrides } from './ComponentOverrides'
 
 export type Variants = 'light' | 'dark'
 
@@ -28,9 +29,11 @@ export interface Props {
   logFilter?: Function
   logGrouping?: Boolean
   linkifyOptions?: Options
+  components?: ComponentOverrides
 }
 
 export interface MessageProps {
   log: Message
   linkifyOptions?: Options
+  components?: ComponentOverrides
 }

--- a/src/definitions/ComponentOverrides.d.ts
+++ b/src/definitions/ComponentOverrides.d.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react'
-import { Message } from './Console'
+import { Message } from './Component'
 
 export interface ComponentOverrides {
   Message?: ComponentType<{

--- a/src/definitions/ComponentOverrides.d.ts
+++ b/src/definitions/ComponentOverrides.d.ts
@@ -1,0 +1,10 @@
+import { ComponentType } from 'react'
+import { Message } from './Console'
+
+export interface ComponentOverrides {
+  Message?: ComponentType<{
+    node?: JSX.Element
+    log?: Message
+    children: React.ReactNode
+  }>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,8 @@ export { default as Console } from './Component'
 export { default as Hook } from './Hook'
 export { default as Unhook } from './Unhook'
 
+import { ComponentOverrides as _ComponentOverrides } from './definitions/ComponentOverrides'
+export type ComponentOverrides = _ComponentOverrides
+
 export { Decode } from './Transform'
 export { Encode } from './Transform'


### PR DESCRIPTION
In some cases, just providing custom colors/styles isn't enough, and a user of the client library may want to more deeply customize the console feed layout.

This PR adds a `components` prop that would allow swapping out implementations of specific child components (for now just `Message`), which are currently opaque to users of `console-feed`. Here's an example snippet of what this PR enables:

```jsx
const foo = <Console
  // ...
  components={{
    Message: MyMessage,
  }}
/>
```

Where `MyMessage` is defined like so:

```jsx
const MyMessage: ComponentOverrides['Message'] = (({ log, node }) => {
  return <div data-method={log.method}>
    {/*
      In this example, we render just the content `node`, not all of the other `children` in the
      original message (i.e. the icon, timestamp, etc.), and add our own custom child for error
      logs.
    */}
    {node}
    {log.method === 'error' && <button>Debug</button>}
  </div>;
});
```