### PR TITLE
chore(pkg): support react 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "peerDependencies": {
-    "react": "^15.x || ^16.x || ^17.x || ^18.x"
+    "react": "^15.x || ^16.x || ^17.x || ^18.x || ^19.x"
   },
   "files": [
     "es",


### PR DESCRIPTION
This is a PR that modifies `package.json` to support React 19, which recently moved from RC to general release.

Currently, without this, trying to install `console-feed` will result in a dependency error, forcing you to install it via `--force`.

Fortunately, after installing it with the `--force` option in my project, I found no issues in the React 19 environment.

Therefore, I hope you will consider this PR and release a corresponding release to support React 19.

Regards,